### PR TITLE
add json stream method

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -321,7 +321,14 @@ public class TRexClient {
         payload.put("stream", stream);
         callMethod("add_stream", payload);
     }
-    
+
+    public void addStream(int portIndex, int streamId, JsonObject stream) {
+        Map<String, Object> payload = createPayload(portIndex);
+        payload.put("stream_id", streamId);
+        payload.put("stream", stream);
+        callMethod("add_stream", payload);
+    }
+
     public Stream getStream(int portIndex, int streamId) {
         Map<String, Object> payload = createPayload(portIndex);
         payload.put("get_pkt", true);


### PR DESCRIPTION
Add new method to create a stream from Json object.
It is possible to create json from YAML or python and with this method we can add this to a stream.

Signed-off-by: Emil Gustafsson <emil.gustafsson@ericsson.com>