### PR TITLE
Add vm instructions

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -8,6 +8,7 @@ import com.cisco.trex.stateless.model.capture.CaptureMonitor;
 import com.cisco.trex.stateless.model.capture.CaptureMonitorStop;
 import com.cisco.trex.stateless.model.capture.CapturedPackets;
 import com.cisco.trex.stateless.model.port.PortVlan;
+import com.cisco.trex.stateless.model.vm.VMInstruction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.gson.*;

--- a/src/main/java/com/cisco/trex/stateless/model/StreamVM.java
+++ b/src/main/java/com/cisco/trex/stateless/model/StreamVM.java
@@ -2,6 +2,8 @@ package com.cisco.trex.stateless.model;
 
 import java.util.List;
 
+import com.cisco.trex.stateless.model.vm.VMInstruction;
+
 public class StreamVM {
     private String split_by_var;
     private List<VMInstruction> instructions;

--- a/src/main/java/com/cisco/trex/stateless/model/VMInstruction.java
+++ b/src/main/java/com/cisco/trex/stateless/model/VMInstruction.java
@@ -1,5 +1,0 @@
-package com.cisco.trex.stateless.model;
-
-public class VMInstruction {
-    
-}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/FixChecksumIpv4.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/FixChecksumIpv4.java
@@ -1,0 +1,22 @@
+package com.cisco.trex.stateless.model.vm;
+
+public class FixChecksumIpv4 extends VMInstruction {
+
+    private String type;
+    private int pkt_offset;
+
+    public FixChecksumIpv4(int pkt_offset) {
+        super();
+        this.type = "fix_checksum_ipv4";
+        this.pkt_offset = pkt_offset;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getPkt_offset() {
+        return pkt_offset;
+    }
+
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/FlowVar.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/FlowVar.java
@@ -1,0 +1,75 @@
+package com.cisco.trex.stateless.model.vm;
+
+import java.util.List;
+
+public class FlowVar extends VMInstruction {
+
+    private String type;
+    private String name;
+    private int size;
+    private String op;
+    private long init_value;
+    private long min_value;
+    private long max_value;
+    private long step = 1;
+    private List<Long> value_list;
+
+    public FlowVar(String name, int size, VariableOperation op, long init_value, long min_value, long max_value,
+            long step) {
+        super();
+        this.type = "flow_var";
+        this.name = name;
+        this.size = size;
+        this.op = op.getValue();
+        this.init_value = init_value;
+        this.min_value = min_value;
+        this.max_value = max_value;
+        this.step = step;
+    }
+
+    public FlowVar(String name, int size, VariableOperation op, List<Long> value_list) {
+        super();
+        this.type = "flow_var";
+        this.name = name;
+        this.size = size;
+        this.op = op.getValue();
+        this.value_list = value_list;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public String getOp() {
+        return op;
+    }
+
+    public long getInit_value() {
+        return init_value;
+    }
+
+    public long getMin_value() {
+        return min_value;
+    }
+
+    public long getMax_value() {
+        return max_value;
+    }
+
+    public long getStep() {
+        return step;
+    }
+
+    public List<Long> getValueList() {
+        return value_list;
+    }
+
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/FlowVarRandLimit.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/FlowVarRandLimit.java
@@ -1,0 +1,52 @@
+package com.cisco.trex.stateless.model.vm;
+
+public class FlowVarRandLimit extends VMInstruction {
+
+    private String type;
+    private String name;
+    private int size;
+    private int limit;
+    private long seed;
+    private long min_value;
+    private long max_value;
+
+    public FlowVarRandLimit(String name, int size, int limit, long seed, long min_value, long max_value) {
+        super();
+        this.type = "flow_var_rand_limit";
+        this.name = name;
+        this.size = size;
+        this.limit = limit;
+        this.seed = seed;
+        this.min_value = min_value;
+        this.max_value = max_value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public long getSeed() {
+        return seed;
+    }
+
+    public long getMin_value() {
+        return min_value;
+    }
+
+    public long getMax_value() {
+        return max_value;
+    }
+
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/VMInstruction.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/VMInstruction.java
@@ -1,0 +1,5 @@
+package com.cisco.trex.stateless.model.vm;
+
+public class VMInstruction {
+    
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/VariableOperation.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/VariableOperation.java
@@ -1,0 +1,18 @@
+package com.cisco.trex.stateless.model.vm;
+
+public enum VariableOperation {
+    INC("inc"),
+    DEC("dec"),
+    RANDOM("random");
+
+    String op;
+
+    VariableOperation(String op) {
+        this.op = op;
+    }
+
+    String getValue() {
+        return op;
+    }
+
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/WriteFlowVar.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/WriteFlowVar.java
@@ -1,0 +1,40 @@
+package com.cisco.trex.stateless.model.vm;
+
+public class WriteFlowVar extends VMInstruction {
+
+    private String type;
+    private String name;
+    private int pkt_offset;
+    private int add_value;
+    private boolean is_big_endian;
+
+    public WriteFlowVar(String name, int pkt_offset, int add_value, boolean is_big_endian) {
+        super();
+        this.type = "write_flow_var";
+        this.name = name;
+        this.pkt_offset = pkt_offset;
+        this.add_value = add_value;
+        this.is_big_endian = is_big_endian;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPkt_offset() {
+        return pkt_offset;
+    }
+
+    public int getAdd_value() {
+        return add_value;
+    }
+
+    public Boolean getIs_big_endian() {
+        return is_big_endian;
+    }
+
+}

--- a/src/main/java/com/cisco/trex/stateless/model/vm/WriteMaskFlowVar.java
+++ b/src/main/java/com/cisco/trex/stateless/model/vm/WriteMaskFlowVar.java
@@ -1,0 +1,59 @@
+package com.cisco.trex.stateless.model.vm;
+
+public class WriteMaskFlowVar extends VMInstruction {
+
+    private String type;
+    private String name;
+    private int pkt_offset;
+    private int add_value;
+    private int pkt_cast_size;
+    private int mask;
+    private int shift;
+    private boolean is_big_endian;
+
+    public WriteMaskFlowVar(String name, int pkt_offset, int add_value, int pkt_cast_size, int mask, int shift,
+            boolean is_big_endian) {
+        super();
+        this.type = "write_mask_flow_var";
+        this.name = name;
+        this.pkt_offset = pkt_offset;
+        this.add_value = add_value;
+        this.pkt_cast_size = pkt_cast_size;
+        this.mask = mask;
+        this.shift = shift;
+        this.is_big_endian = is_big_endian;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPkt_offset() {
+        return pkt_offset;
+    }
+
+    public int getAdd_value() {
+        return add_value;
+    }
+
+    public int getPkt_cast_size() {
+        return pkt_cast_size;
+    }
+
+    public int getMask() {
+        return mask;
+    }
+
+    public int getShift() {
+        return shift;
+    }
+
+    public boolean getIs_big_endian() {
+        return is_big_endian;
+    }
+
+}

--- a/src/test/java/com/cisco/trex/stateless/TRexClientTest.java
+++ b/src/test/java/com/cisco/trex/stateless/TRexClientTest.java
@@ -10,6 +10,8 @@ import com.cisco.trex.stateless.model.capture.CaptureMonitor;
 import com.cisco.trex.stateless.model.capture.CaptureMonitorStop;
 import com.cisco.trex.stateless.model.capture.CapturedPackets;
 import com.cisco.trex.stateless.model.port.PortVlan;
+import com.cisco.trex.stateless.model.vm.VMInstruction;
+
 import org.junit.*;
 import org.pcap4j.packet.ArpPacket;
 import org.pcap4j.packet.EthernetPacket;


### PR DESCRIPTION
Currently there is only a empty abstraction for vm instruction named "VMInstruction" in package com.cisco.trex.stateless.model.

to facility user to build up stream with concrete vm instrucions to utilize field engine in RPC calling , this commit implements below vm instructions:
  -fix_checksum_ipv4
  -flow_var
  -flow_var_rand_limit
  -write_flow_var
  -write_mask_flow_var

meanwhile the "VMInstruction" are moved into a new created package com.cisco.trex.stateless.model.vm along with instruction java implementations.
 
all these classes are well tested with a real TRex RPC service and works well.

Signed-off-by: Leo Ma <leo.ma@ericsson.com>