### PR TITLE
cleanup temporary created streams for resolveArp and sendIcmpV6Echo

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
+++ b/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
@@ -1,55 +1,25 @@
 package com.cisco.trex.stateless;
 
-import static org.pcap4j.util.ByteArrays.BYTE_SIZE_IN_BYTES;
-
-import java.net.Inet6Address;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.pcap4j.packet.EthernetPacket;
-import org.pcap4j.packet.IcmpV6CommonPacket;
+import com.cisco.trex.stateless.exception.ServiceModeRequiredException;
+import com.cisco.trex.stateless.model.*;
+import com.google.common.net.InetAddresses;
+import org.pcap4j.packet.*;
 import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
-import org.pcap4j.packet.IcmpV6EchoReplyPacket;
-import org.pcap4j.packet.IcmpV6EchoRequestPacket;
-import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket;
 import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket.IcmpV6NeighborAdvertisementHeader;
-import org.pcap4j.packet.IcmpV6NeighborSolicitationPacket;
-import org.pcap4j.packet.IllegalRawDataException;
-import org.pcap4j.packet.IpV6NeighborDiscoverySourceLinkLayerAddressOption;
-import org.pcap4j.packet.IpV6NeighborDiscoveryTargetLinkLayerAddressOption;
-import org.pcap4j.packet.IpV6Packet;
-import org.pcap4j.packet.IpV6SimpleFlowLabel;
-import org.pcap4j.packet.IpV6SimpleTrafficClass;
-import org.pcap4j.packet.Packet;
-import org.pcap4j.packet.namednumber.EtherType;
-import org.pcap4j.packet.namednumber.IcmpV6Code;
-import org.pcap4j.packet.namednumber.IcmpV6Type;
-import org.pcap4j.packet.namednumber.IpNumber;
-import org.pcap4j.packet.namednumber.IpVersion;
+import org.pcap4j.packet.namednumber.*;
 import org.pcap4j.util.ByteArrays;
 import org.pcap4j.util.MacAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.cisco.trex.stateless.exception.ServiceModeRequiredException;
-import com.cisco.trex.stateless.model.Ipv6Node;
-import com.cisco.trex.stateless.model.PortStatus;
-import com.cisco.trex.stateless.model.StreamMode;
-import com.cisco.trex.stateless.model.StreamModeRate;
-import com.cisco.trex.stateless.model.StreamRxStats;
-import com.cisco.trex.stateless.model.StreamVM;
-import com.cisco.trex.stateless.model.TRexClientResult;
-import com.google.common.net.InetAddresses;
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.pcap4j.util.ByteArrays.BYTE_SIZE_IN_BYTES;
 
 public class IPv6NeighborDiscoveryService {
 

--- a/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
+++ b/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
@@ -1,25 +1,55 @@
 package com.cisco.trex.stateless;
 
-import com.cisco.trex.stateless.exception.ServiceModeRequiredException;
-import com.cisco.trex.stateless.model.*;
-import com.google.common.net.InetAddresses;
-import org.pcap4j.packet.*;
+import static org.pcap4j.util.ByteArrays.BYTE_SIZE_IN_BYTES;
+
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.pcap4j.packet.EthernetPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket;
 import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
+import org.pcap4j.packet.IcmpV6EchoReplyPacket;
+import org.pcap4j.packet.IcmpV6EchoRequestPacket;
+import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket;
 import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket.IcmpV6NeighborAdvertisementHeader;
-import org.pcap4j.packet.namednumber.*;
+import org.pcap4j.packet.IcmpV6NeighborSolicitationPacket;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.IpV6NeighborDiscoverySourceLinkLayerAddressOption;
+import org.pcap4j.packet.IpV6NeighborDiscoveryTargetLinkLayerAddressOption;
+import org.pcap4j.packet.IpV6Packet;
+import org.pcap4j.packet.IpV6SimpleFlowLabel;
+import org.pcap4j.packet.IpV6SimpleTrafficClass;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.namednumber.EtherType;
+import org.pcap4j.packet.namednumber.IcmpV6Code;
+import org.pcap4j.packet.namednumber.IcmpV6Type;
+import org.pcap4j.packet.namednumber.IpNumber;
+import org.pcap4j.packet.namednumber.IpVersion;
 import org.pcap4j.util.ByteArrays;
 import org.pcap4j.util.MacAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.Inet6Address;
-import java.net.UnknownHostException;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.pcap4j.util.ByteArrays.BYTE_SIZE_IN_BYTES;
+import com.cisco.trex.stateless.exception.ServiceModeRequiredException;
+import com.cisco.trex.stateless.model.Ipv6Node;
+import com.cisco.trex.stateless.model.PortStatus;
+import com.cisco.trex.stateless.model.StreamMode;
+import com.cisco.trex.stateless.model.StreamModeRate;
+import com.cisco.trex.stateless.model.StreamRxStats;
+import com.cisco.trex.stateless.model.StreamVM;
+import com.cisco.trex.stateless.model.TRexClientResult;
+import com.google.common.net.InetAddresses;
 
 public class IPv6NeighborDiscoveryService {
 
@@ -116,7 +146,12 @@ public class IPv6NeighborDiscoveryService {
                 }
             }
         }
+
         tRexClient.removeRxQueue(portIdx);
+        if (tRexClient.getPortStatus(portIdx).get().getState().equals("TX")) {
+            tRexClient.stopTraffic(portIdx);
+        }
+        tRexClient.removeAllStreams(portIdx);
         return icmpUnicastReply;
 
     }

--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -1,65 +1,8 @@
 package com.cisco.trex.stateless;
 
-import static java.lang.Math.abs;
-
-import java.io.IOException;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Random;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import org.pcap4j.packet.ArpPacket;
-import org.pcap4j.packet.Dot1qVlanTagPacket;
-import org.pcap4j.packet.EthernetPacket;
-import org.pcap4j.packet.IcmpV4CommonPacket;
-import org.pcap4j.packet.IcmpV4EchoPacket;
-import org.pcap4j.packet.IcmpV4EchoReplyPacket;
-import org.pcap4j.packet.IllegalRawDataException;
-import org.pcap4j.packet.IpV4Packet;
-import org.pcap4j.packet.IpV4Rfc791Tos;
-import org.pcap4j.packet.Packet;
-import org.pcap4j.packet.namednumber.ArpHardwareType;
-import org.pcap4j.packet.namednumber.ArpOperation;
-import org.pcap4j.packet.namednumber.EtherType;
-import org.pcap4j.packet.namednumber.IcmpV4Code;
-import org.pcap4j.packet.namednumber.IcmpV4Type;
-import org.pcap4j.packet.namednumber.IpNumber;
-import org.pcap4j.packet.namednumber.IpVersion;
-import org.pcap4j.util.ByteArrays;
-import org.pcap4j.util.MacAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.zeromq.ZMQException;
-
 import com.cisco.trex.stateless.exception.ServiceModeRequiredException;
 import com.cisco.trex.stateless.exception.TRexConnectionException;
-import com.cisco.trex.stateless.model.ApiVersion;
-import com.cisco.trex.stateless.model.Ipv6Node;
-import com.cisco.trex.stateless.model.L2Configuration;
-import com.cisco.trex.stateless.model.Port;
-import com.cisco.trex.stateless.model.PortStatus;
-import com.cisco.trex.stateless.model.RPCResponse;
-import com.cisco.trex.stateless.model.Stream;
-import com.cisco.trex.stateless.model.StreamMode;
-import com.cisco.trex.stateless.model.StreamModeRate;
-import com.cisco.trex.stateless.model.StreamRxStats;
-import com.cisco.trex.stateless.model.StreamVM;
-import com.cisco.trex.stateless.model.StubResult;
-import com.cisco.trex.stateless.model.SystemInfo;
-import com.cisco.trex.stateless.model.TRexClientResult;
+import com.cisco.trex.stateless.model.*;
 import com.cisco.trex.stateless.model.capture.CaptureInfo;
 import com.cisco.trex.stateless.model.capture.CaptureMonitor;
 import com.cisco.trex.stateless.model.capture.CaptureMonitorStop;
@@ -68,13 +11,26 @@ import com.cisco.trex.stateless.model.port.PortVlan;
 import com.cisco.trex.stateless.model.vm.VMInstruction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
+import com.google.gson.*;
 import javafx.util.Pair;
+import org.pcap4j.packet.*;
+import org.pcap4j.packet.namednumber.*;
+import org.pcap4j.util.ByteArrays;
+import org.pcap4j.util.MacAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.ZMQException;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.lang.Math.abs;
 
 public class TRexClient {
 


### PR DESCRIPTION
This commit is for fix potential problem on calling TRexClient.resolveArp() and TRexClient.sendIcmpV6Echo().

In above two methods, streams are created to send the ARP/NS frames, but at the end of calling, these streams are not removed and the traffic are still in TX status. This commit is trying to fix this problem via stop traffic and remove all temporary streams at end of methods.

meanwhile, some imports reorgnization is done to make imports lines in a more readable order

