### PR TITLE
Implemented request compression and decompression in TRexTransport

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -19,7 +19,6 @@ import org.pcap4j.util.ByteArrays;
 import org.pcap4j.util.MacAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zeromq.ZMQException;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -98,18 +97,7 @@ public class TRexClient {
     }
 
     private String call(String json) {
-        LOGGER.info("JSON Req: " + json);
-        byte[] msg = transport.sendJson(json);
-        if (msg == null) {
-            int errNumber = transport.getSocket().base().errno();
-            String errMsg = "Unable to receive message from socket";
-            ZMQException zmqException = new ZMQException(errMsg, errNumber);
-            LOGGER.error(errMsg, zmqException);
-            throw zmqException;
-        }
-        String response = new String(msg);
-        LOGGER.info("JSON Resp: " + response);
-        return response;
+        return transport.sendJson(json);
     }
 
     public <T> TRexClientResult<T> callMethod(String methodName, Map<String, Object> parameters, Class<T> responseType) {

--- a/src/main/java/com/cisco/trex/stateless/util/IDataCompressor.java
+++ b/src/main/java/com/cisco/trex/stateless/util/IDataCompressor.java
@@ -1,0 +1,6 @@
+package com.cisco.trex.stateless.util;
+
+public interface IDataCompressor {
+    byte[] compressStringToBytes(String request);
+    String decompressBytesToString(byte[] data);
+}

--- a/src/main/java/com/cisco/trex/stateless/util/TRexDataCompressor.java
+++ b/src/main/java/com/cisco/trex/stateless/util/TRexDataCompressor.java
@@ -1,0 +1,91 @@
+package com.cisco.trex.stateless.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+public class TRexDataCompressor implements IDataCompressor {
+    // Magic bytes from TrexRpcZip
+    private static final byte[] TREX_HEADER_MAGIC =  new byte[] {(byte)0xAB, (byte)0xE8, (byte)0x5C, (byte)0xEA};
+    private static final int HEADER_SIZE = 8; // 4 magic bytes and 4 bytes Integer (request length)
+    private static final Logger LOGGER = LoggerFactory.getLogger(TRexDataCompressor.class);;
+
+    @Override
+    public byte[] compressStringToBytes(String request) {
+        // prepare compression header
+        ByteBuffer headerByteBuffer = ByteBuffer.allocate(HEADER_SIZE);
+        headerByteBuffer.put(TREX_HEADER_MAGIC);
+        headerByteBuffer.putInt(request.length());
+        byte[] headerBytes = headerByteBuffer.array();
+
+        // compress request
+        byte[] compressedRequest = compressBytes(request.getBytes());
+
+        return concatByteArrays(headerBytes, compressedRequest);
+    }
+
+    @Override
+    public String decompressBytesToString(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        if (data.length > HEADER_SIZE) {
+
+            byte[] magicBytes = Arrays.copyOfRange(data, 0, TREX_HEADER_MAGIC.length);
+            if (Arrays.equals(magicBytes, TREX_HEADER_MAGIC)) {
+
+                // Skip another  4 bytes containing the uncompressed size of the  message
+                byte[] compressedData = Arrays.copyOfRange(data, HEADER_SIZE, data.length);
+                try {
+                    return new String(decompressBytes(compressedData));
+                } catch (DataFormatException ex) {
+                    LOGGER.error("Header is correct, but unable to decompress data", ex);
+                }
+            }
+        }
+
+        return new String(data);
+    }
+
+    private byte[] concatByteArrays(byte[] firstDataArray, byte[] secondDataArray) {
+        byte[] concatedDataArray = new byte[firstDataArray.length + secondDataArray.length];
+        System.arraycopy(firstDataArray, 0, concatedDataArray, 0, firstDataArray.length);
+        System.arraycopy(secondDataArray, 0, concatedDataArray, firstDataArray.length, secondDataArray.length);
+        return concatedDataArray;
+    }
+
+    private byte[] compressBytes (byte[] data)  {
+        Deflater deflater = new Deflater();
+        deflater.setInput(data);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        deflater.finish();
+        byte[] buffer = new byte[1024];
+
+        while (!deflater.finished()) {
+            int count = deflater.deflate(buffer);
+            outputStream.write(buffer, 0, count);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private byte[] decompressBytes (byte[] data) throws DataFormatException {
+        Inflater inflater = new Inflater();
+        inflater.setInput(data);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        byte[] buffer = new byte[1024];
+        while (!inflater.finished()) {
+            int count = inflater.inflate(buffer);
+            outputStream.write(buffer, 0, count);
+        }
+
+        return outputStream.toByteArray();
+    }
+}

--- a/src/test/java/com/cisco/trex/stateless/model/port/PortVlanTest.java
+++ b/src/test/java/com/cisco/trex/stateless/model/port/PortVlanTest.java
@@ -1,15 +1,12 @@
 package com.cisco.trex.stateless.model.port;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class PortVlanTest {
     @Test

--- a/src/test/java/com/cisco/trex/stateless/util/TRexDataCompressorTest.java
+++ b/src/test/java/com/cisco/trex/stateless/util/TRexDataCompressorTest.java
@@ -1,0 +1,65 @@
+package com.cisco.trex.stateless.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class TRexDataCompressorTest {
+
+    private TRexDataCompressor compressor;
+    private String requestJsonString;
+    private String responseJsonString;
+    private byte[] requestCompressedBytes;
+    private byte[] responseCompressedBytes;
+
+    @Before
+    public void setUp() {
+        compressor = new TRexDataCompressor();
+
+        requestJsonString = "{\"method\":\"api_sync\",\"id\":672327041,\"jsonrpc\":\"2.0\",\"params\":{\"api_h\":null,\"api_vers\":[{\"major\":4,\"minor\":0,\"type\":\"core\"}]}}";
+
+        responseJsonString = "[{\"id\":672327041,\"jsonrpc\":\"2.0\",\"result\":{\"api_vers\":[{\"api_h\":\"0E1vxb39\",\"type\":\"core\"}]}}]\n";
+
+        requestCompressedBytes = new byte[]{-85, -24, 92, -22, 0, 0, 0, 125, 120, -100, 29, -116, -37, 10, -125, 48, 16, 68, -1, 101, -98, 23, 73, -93, 84, -56, -81, -108, 82, 66, 26, 48, 98, 46, 108, 84, -112, -112, 127, -17, -42, -73, 57, -100, -103, 105, -120, 126, 95, -14, 23, 6, -74, -124, 79, -67, -110, 3, 33, 8, 63, 103, 61, -22, 89, 77, 15, -62, 90, 115, -30, -30, -92, -93, 7, 37, -70, 88, -74, -79, -62, -76, 123, -77, -64, -92, 99, -37, -24, -122, -45, -77, -120, 87, 67, -76, 107, 102, -104, -119, 16, 67, -6, 39, 69, -40, -81, -30, -27, -60, 101, -10, -24, -17, -34, 127, -120, -111, 39, -116};
+        responseCompressedBytes = new byte[]{-85, -24, 92, -22, 0, 0, 0, 94, 120, -100, -117, -82, 86, -54, 76, 81, -78, 50, 51, 55, 50, 54, 50, 55, 48, 49, -44, 81, -54, 42, -50, -49, 43, 42, 72, 86, -78, 82, 50, -46, 51, 80, -46, 81, 42, 74, 45, 46, -51, 41, 81, -78, -86, 86, 74, 44, -56, -116, 47, 75, 45, 42, 86, -78, -118, -122, 112, 50, -128, -118, 12, 92, 13, -53, 42, -110, -116, 45, -127, 42, 75, 42, 11, 82, -127, 34, -55, -7, 69, -87, 74, -75, -79, -75, -75, -79, 92, 0, 31, 2, 28, -103};
+    }
+
+    @Test
+    public void compressDecompress() {
+        byte[] compressedRequest = compressor.compressStringToBytes(requestJsonString);
+
+        String decompressedRequest = compressor.decompressBytesToString(compressedRequest);
+
+        assertEquals(decompressedRequest, requestJsonString);
+
+        byte[] compressedResponse = compressor.compressStringToBytes(responseJsonString);
+        String decompressedResponse = compressor.decompressBytesToString(compressedResponse);
+
+        assertEquals(decompressedResponse, responseJsonString);
+    }
+
+
+    @Test
+    public void compressStringToBytes() {
+        byte[] compressedRequest = compressor.compressStringToBytes(requestJsonString);
+
+        assertArrayEquals(requestCompressedBytes, compressedRequest);
+
+        byte[] compressedResponse = compressor.compressStringToBytes(responseJsonString);
+
+        assertArrayEquals(compressedResponse, responseCompressedBytes);
+    }
+
+    @Test
+    public void decompressBytesToString() {
+        String decompressedRequest = compressor.decompressBytesToString(requestCompressedBytes);
+
+        assertEquals(decompressedRequest, requestJsonString);
+
+        String decompressedResponse = compressor.decompressBytesToString(responseCompressedBytes);
+
+        assertEquals(decompressedResponse, responseJsonString);
+    }
+}


### PR DESCRIPTION
- Removed transport logic from `TRexClient`
- Optimized and simplified work with `ZMQ.Socket` (on `recv()` method, there called `mayRaise()` method also, this method raises an exception if there is an error)
- Compression and decompression logic implemented in `TRexDataCompressor`
- Covered `TRexDataCompressor` with Tests