### PR TITLE
Xstats and pgid stats support

### DIFF
--- a/src/e2e-test/docker/Dockerfile
+++ b/src/e2e-test/docker/Dockerfile
@@ -1,0 +1,27 @@
+# 1. build the image:
+#	sudo docker build -t trex-java-sdk-testing .
+#
+# 2. run the container:
+#   sudo docker run -it --cap-add=ALL --privileged --rm -p 4500:4500 -p 4501:4501 -p 4507:4507 trex-java-sdk-testing
+#
+# 3. run TRex within just started container:
+#	[root@<...> v2.49]# sudo ./t-rex-64 -i
+#
+# 4. run e2e tests on trex-java-sdk:
+#	cd trex-java-sdk
+#	$ echo $JAVA_HOME 
+#	/usr/lib/jvm/java-8-oracle
+#	$ ./gradlew e2eTest -i
+#
+# NOTE. iPV6ScanTest is flaky, it works only on the second or third try. It has to be fixed.
+
+
+FROM trexcisco/trex
+
+LABEL RUN docker run --privileged --cap-add=ALL --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+RUN rm -r /var/trex/v2.41
+WORKDIR /var/trex
+RUN curl http://trex-tgn.cisco.com/trex/release/latest | tar -zxvf -
+COPY startup.sh /run/startup.sh
+ENTRYPOINT "/run/startup.sh" && /bin/bash
+

--- a/src/e2e-test/docker/startup.sh
+++ b/src/e2e-test/docker/startup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sysctl net.ipv6.conf.all.disable_ipv6=0
+

--- a/src/e2e-test/java/com/cisco/trex/stateless/TRexClientBPFTest.java
+++ b/src/e2e-test/java/com/cisco/trex/stateless/TRexClientBPFTest.java
@@ -24,6 +24,10 @@ public class TRexClientBPFTest {
     public static void setUp() throws TRexConnectionException, TRexTimeoutException {
         client = new TRexClient("trex-host", "4501", CLIENT_USER);
         client.connect();
+        client.getPorts().forEach(p -> {
+            client.acquirePort(p.getIndex(), true);
+            client.serviceMode(p.getIndex(), true);
+        });
     }
 
     @Test
@@ -102,7 +106,7 @@ public class TRexClientBPFTest {
 
         public CaptureTester(CaptureMonitorStarter s, String filter) {
             TRexClientResult<CaptureMonitor> startResult = s.start(filter);
-            Assert.assertFalse(startResult.isFailed());
+            Assert.assertFalse(startResult.getError(), startResult.isFailed());
             monitor = startResult.get();
         }
 

--- a/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
+++ b/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
@@ -531,6 +531,7 @@ public class TRexClientTest {
     }
 
     @Test
+    @Ignore
     public void sendIcmpV6EchoTest() {
         List<Port> ports = client.getPorts();
         for (Port port : ports) {

--- a/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
+++ b/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
@@ -85,7 +85,7 @@ public class TRexClientTest {
     }
 
     private PortStatus getPortStatus(int portIdx) {
-        try{
+        try {
             TRexClientResult<PortStatus> result = client.getPortStatus(portIdx);
             if (result.isFailed()) {
                 Assert.fail(result.getError());
@@ -119,11 +119,11 @@ public class TRexClientTest {
     public void serviceModeOnOffTest() {
         List<Port> ports = client.getPorts();
         Port port = ports.get(0);
-        
+
         client.acquirePort(port.getIndex(), true);
         PortStatus serviceModePortStatus = client.serviceMode(port.getIndex(), true);
         Assert.assertTrue(serviceModePortStatus.service);
-        
+
         client.serviceMode(port.getIndex(), false);
         PortStatus normalModePortStatus = client.serviceMode(port.getIndex(), false);
         Assert.assertFalse(normalModePortStatus.service);
@@ -136,26 +136,26 @@ public class TRexClientTest {
         Stream stream = buildStream(SIMPLE_PACKET);
         client.acquirePort(port.getIndex(), true);
         client.addStream(port.getIndex(), stream);
-        
+
         List<Integer> streamIds = client.getStreamIds(port.getIndex());
         Assert.assertTrue(streamIds.contains(stream.getId()));
         client.releasePort(port.getIndex());
     }
-    
+
 
     @Test
     public void removeStreamTest() {
         List<Port> ports = client.getPorts();
         Port port = ports.get(0);
         Stream stream = buildStream(SIMPLE_PACKET);
-        
+
         client.acquirePort(port.getIndex(), true);
         client.addStream(port.getIndex(), stream);
         client.removeStream(port.getIndex(), stream.getId());
-        
+
         List<Integer> streamIds = client.getStreamIds(port.getIndex());
         Assert.assertTrue(!streamIds.contains(stream.getId()));
-        
+
         client.releasePort(port.getIndex());
     }
 
@@ -163,16 +163,16 @@ public class TRexClientTest {
     public void removeAllStreamsTest() {
         List<Port> ports = client.getPorts();
         Port port = ports.get(0);
-        
+
         Stream s = buildStream(SIMPLE_PACKET);
-        
+
         client.acquirePort(port.getIndex(), true);
         client.addStream(port.getIndex(), s);
         client.removeAllStreams(port.getIndex());
-        
+
         List<Integer> streamIds = client.getStreamIds(port.getIndex());
         Assert.assertTrue(streamIds.isEmpty());
-        
+
         client.releasePort(port.getIndex());
     }
 
@@ -180,14 +180,14 @@ public class TRexClientTest {
     public void getStreamTest() {
         List<Port> ports = client.getPorts();
         Port port = ports.get(0);
-        
+
         Stream s = buildStream(SIMPLE_PACKET);
         client.acquirePort(port.getIndex(), true);
         client.addStream(port.getIndex(), s);
-        
+
         Stream streamFromTrex = client.getStream(port.getIndex(), s.getId());
         Assert.assertTrue(s.equals(streamFromTrex));
-        
+
         client.releasePort(port.getIndex());
     }
 
@@ -232,7 +232,7 @@ public class TRexClientTest {
             client.releasePort(port.getIndex());
         }
     }
-    
+
     @Test
     public void startStopTrafficTest() {
         List<Port> ports = client.getPorts();
@@ -247,14 +247,14 @@ public class TRexClientTest {
         mul.put("type", "pps");
         mul.put("value", 1.0);
         client.startTraffic(port.getIndex(), -1.0, true, mul, 1);
-        
+
         PortStatus portStatusTX = client.getPortStatus(port.getIndex()).get();
         Assert.assertTrue(portStatusTX.state.equals("TX"));
         client.stopTraffic(port.getIndex());
 
         PortStatus portStatusStream = client.getPortStatus(port.getIndex()).get();
         Assert.assertTrue(portStatusStream.state.equals("STREAMS"));
-        
+
         client.releasePort(port.getIndex());
     }
 
@@ -269,18 +269,18 @@ public class TRexClientTest {
         Port port1 = ports.get(1);
         client.acquirePort(port.getIndex(), true);
         client.acquirePort(port1.getIndex(), true);
-        
+
         client.serviceMode(port.getIndex(), true);
         client.serviceMode(port1.getIndex(), true);
 
         client.removeRxQueue(port.getIndex());
         client.setRxQueue(port.getIndex(), 5);
-            
+
         Packet pkt = SIMPLE_PACKET;
         client.sendPacket(port.getIndex(), pkt);
 
         Predicate<EthernetPacket> arpReplyFilter = etherPkt -> {
-            if(etherPkt.contains(ArpPacket.class)) {
+            if (etherPkt.contains(ArpPacket.class)) {
                 ArpPacket arp = (ArpPacket) etherPkt.getPayload();
                 if (ArpOperation.REPLY.equals(arp.getHeader().getOperation())) {
                     return true;
@@ -299,13 +299,13 @@ public class TRexClientTest {
     public void getCapturesTest() {
         List<Port> ports = client.getPorts();
 
-        for(Port port : ports) {
+        for (Port port : ports) {
             client.acquirePort(port.getIndex(), true);
             client.serviceMode(port.getIndex(), true);
         }
 
         client.removeAllCaptures();
-        
+
         TRexClientResult<CaptureMonitor> result = startMonitor(ports);
         Assert.assertFalse(result.isFailed());
 
@@ -319,10 +319,10 @@ public class TRexClientTest {
 
         Assert.assertTrue(monitorInfoResult.isPresent());
     }
-    
+
     private TRexClientResult<CaptureMonitor> startMonitor(List<Port> portList) {
         List<Integer> rxPorts = new LinkedList<Integer>();
-        if (portList.size()>0) {
+        if (portList.size() > 0) {
             rxPorts.add(portList.get(0).getIndex());
         }
         List<Integer> txPorts = portList.stream().map(Port::getIndex).collect(Collectors.toList());
@@ -333,13 +333,13 @@ public class TRexClientTest {
     public void startRecorderTest() {
         List<Port> ports = client.getPorts();
 
-        for(Port port : ports) {
+        for (Port port : ports) {
             client.acquirePort(port.getIndex(), true);
             client.serviceMode(port.getIndex(), true);
         }
 
         TRexClientResult<CaptureMonitor> result = startMonitor(ports);
-        
+
         Assert.assertFalse(result.isFailed());
 
         CaptureMonitor capture = result.get();
@@ -348,43 +348,43 @@ public class TRexClientTest {
         Optional<CaptureInfo> recordMonitor = Arrays.stream(activeCaptures.get())
                 .filter(info -> info.getId() == capture.getCaptureId())
                 .findFirst();
-        
+
         Assert.assertTrue(recordMonitor.isPresent());
         Assert.assertEquals("ACTIVE", recordMonitor.get().getState());
     }
-    
+
     @Test
     public void removeAllRecorderTest() {
         TRexClientResult<List<RPCResponse>> result = client.removeAllCaptures();
         Assert.assertFalse(result.isFailed());
     }
-    
+
     @Test
     public void sendMultipleCmdsTest() {
         List<TRexCommand> commands = new ArrayList<>();
-        
+
         for (int i = 1; i <= 10; i++) {
             commands.add(client.buildCommand("sendIcmpV6Request", new HashMap<>()));
         }
 
         TRexClientResult<List<RPCResponse>> result = client.callMethods(commands);
-        
+
         Assert.assertFalse(result.isFailed());
-        
+
         Assert.assertEquals(commands.size(), result.get().size());
     }
-    
+
     @Test
     public void captureRecordStopTest() {
         List<Port> ports = client.getPorts();
 
-        for(Port port : ports) {
+        for (Port port : ports) {
             client.acquirePort(port.getIndex(), true);
             client.serviceMode(port.getIndex(), true);
         }
 
         TRexClientResult<CaptureMonitor> result = startMonitor(client.getPorts());
-        
+
         CaptureMonitor recordMonitor = result.get();
 
         TRexClientResult<CaptureMonitorStop> stopResult = client.captureMonitorStop(result.get().getCaptureId());
@@ -396,17 +396,17 @@ public class TRexClientTest {
         Optional<CaptureInfo> stoppedMonitor = Arrays.stream(activeCapturesResult.get())
                 .filter(captureInfo -> captureInfo.getId() == recordMonitor.getCaptureId())
                 .findFirst();
-        
+
         Assert.assertTrue(stoppedMonitor.isPresent());
-        
+
         Assert.assertEquals("STOPPED", stoppedMonitor.get().getState());
     }
-    
+
     @Test
     public void fetchCapturedPKtsTest() throws InterruptedException {
         List<Port> ports = client.getPorts();
 
-        for (Port port: ports) {
+        for (Port port : ports) {
             client.acquirePort(port.getIndex(), true);
             client.serviceMode(port.getIndex(), true);
         }
@@ -468,9 +468,12 @@ public class TRexClientTest {
         for (Port port : ports) {
             client.acquirePort(port.getIndex(), true);
         }
-
         Stream s = buildStream(SIMPLE_PACKET);
         client.addStream(ports.get(0).getIndex(), s);
+
+        PortStatistics ps0_initial = client.getPortStatistics(ports.get(0).getIndex());
+        PortStatistics ps1_initial = client.getPortStatistics(ports.get(1).getIndex());
+
 
         Map<String, Object> mul = new HashMap<>();
         mul.put("op", "abs");
@@ -489,25 +492,35 @@ public class TRexClientTest {
         Assert.assertTrue(ps1.getTotalRxBytes() > 0);
         Assert.assertTrue(ps1.getTotalRxPackets() > 0);
 
-        double thershold = 0.1;
+        double threshold = 0.1;
 
-        Assert.assertTrue(equalWithRelativeEps(ps0.getTotalTxBytes(), ps1.getTotalRxBytes(), thershold));
-        Assert.assertTrue(equalWithRelativeEps(ps0.getTotalTxPackets(), ps1.getTotalRxPackets(), thershold));
+        Assert.assertTrue(equalWithRelativeEps(
+                ps0.getTotalTxBytes() - ps0_initial.getTotalTxBytes(),
+                ps1.getTotalRxBytes() - ps1_initial.getTotalRxBytes(),
+                threshold
+        ));
+
+        Assert.assertTrue(equalWithRelativeEps(
+                ps0.getTotalTxPackets() - ps0_initial.getTotalTxPackets(),
+                ps1.getTotalRxPackets() - ps1_initial.getTotalRxPackets(),
+                threshold
+        ));
     }
 
     private boolean equalWithRelativeEps(long a, long b, double relativeEps) {
-        long max = a > b? a : b;
+        long max = a > b ? a : b;
         double eps = max * relativeEps;
 
-        return Math.abs(a-b) <= eps;
+        return Math.abs(a - b) <= eps;
     }
 
-        @Test
+    @Test
     public void iPV6ScanTest() {
         List<Port> ports = client.getPorts();
-
-        client.acquirePort(ports.get(0).getIndex(), true);
-        client.serviceMode(ports.get(0).getIndex(), true);
+        for (Port port : ports) {
+            client.acquirePort(port.getIndex(), true);
+            client.serviceMode(port.getIndex(), true);
+        }
 
         try {
             Map<String, Ipv6Node> ipv6Nodes = client.scanIPv6(ports.get(0).getIndex());
@@ -516,36 +529,37 @@ public class TRexClientTest {
             Assert.fail("Port 0 is not in service mode");
         }
     }
-    
+
     @Test
     public void sendIcmpV6EchoTest() {
         List<Port> ports = client.getPorts();
-
-        client.acquirePort(ports.get(0).getIndex(), true);
-        client.serviceMode(ports.get(0).getIndex(), true);
-
+        for (Port port : ports) {
+            client.acquirePort(port.getIndex(), true);
+            client.serviceMode(port.getIndex(), true);
+        }
         try {
-            // fe80:0:0:0:822a:a8ff:fe56:1517
-            // fe80:0:0:0:bc:18ff:fe6a:c570
-            // fe80:0:0:0:250:56ff:fe9b:2ef7
-            Assert.assertTrue(client.sendIcmpV6Echo(ports.get(0).getIndex(), "fe80::822a:a8ff:fec0:5495", 0, 0, 2) != null);
+            Map<String, Ipv6Node> ipv6Nodes = client.scanIPv6(ports.get(0).getIndex());
+            Assert.assertTrue(ipv6Nodes.size() > 0);
+            for (String ipv6Addr : ipv6Nodes.keySet()) {
+                Assert.assertNotNull(client.sendIcmpV6Echo(ports.get(0).getIndex(), ipv6Addr, 0, 0, 2));
+            }
         } catch (ServiceModeRequiredException e) {
             Assert.fail("Port 0 is not in service mode");
         }
     }
-    
+
     @Test
     @Ignore
-    public void sendPacketTest() throws TRexTimeoutException{
+    public void sendPacketTest() throws TRexTimeoutException {
         List<Port> ports = client.getPorts();
         Port port = ports.get(0);
-        
+
         client.acquirePort(port.getIndex(), true);
         client.serviceMode(port.getIndex(), true);
         client.setRxQueue(port.getIndex(), 10);
         List<EthernetPacket> pkts = client.getRxQueue(port.getIndex(), p -> true);
     }
-    
+
     private static EthernetPacket buildIdealPkt(String pkt) {
         byte[] pktBin = Base64.getDecoder().decode(pkt);
         try {
@@ -555,11 +569,28 @@ public class TRexClientTest {
         }
         return null;
     }
-    
+
     @AfterClass
     public static void tierDown() {
-        client.getPorts().stream().forEach(port -> client.stopTraffic(port.getIndex()));
+        client.getPorts().stream().forEach(port -> {
+            client.stopTraffic(port.getIndex());
+            client.resetPort(port.getIndex());
+            client.setVlan(port.getIndex(), new ArrayList<>());
+        });
         client.disconnect();
+    }
+
+    @After
+    public void tearDownMethod() {
+        client.removeAllCaptures();
+        client.getPorts().stream().forEach(port ->
+        {
+            client.stopTraffic(port.getIndex());
+            client.resetPort(port.getIndex());
+            client.setVlan(port.getIndex(), new ArrayList<>());
+            client.serviceMode(port.getIndex(), false);
+            client.releasePort(port.getIndex());
+        });
     }
 
     public static Stream buildStream(Packet pkt) {

--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -313,6 +313,7 @@ public class TRexClient {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("port_id", portIndex);
         return callMethod("get_port_xstats_names", parameters, XstatsNames.class).get();
+    }
 
     public PortStatistics getPortStatistics(int portIndex) {
         Map<String, Object> parameters = new HashMap<>();

--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -8,6 +8,8 @@ import com.cisco.trex.stateless.model.capture.CaptureMonitor;
 import com.cisco.trex.stateless.model.capture.CaptureMonitorStop;
 import com.cisco.trex.stateless.model.capture.CapturedPackets;
 import com.cisco.trex.stateless.model.port.PortVlan;
+import com.cisco.trex.stateless.model.stats.ExtendedPortStatistics;
+import com.cisco.trex.stateless.model.stats.XstatsNames;
 import com.cisco.trex.stateless.model.vm.VMInstruction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -281,6 +283,19 @@ public class TRexClient {
         callMethod("release", payload);
         portHandlers.remove(portIndex);
         return getPortStatus(portIndex).get();
+    }
+    
+    public ExtendedPortStatistics getExtendedPortStatistics(int portIndex) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("port_id", portIndex);
+        return callMethod("get_port_xstats_values", parameters, ExtendedPortStatistics.class).get()
+                .setValueNames(getPortStatNames(portIndex));
+    }
+
+    private XstatsNames getPortStatNames(int portIndex) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("port_id", portIndex);
+        return callMethod("get_port_xstats_names", parameters, XstatsNames.class).get();
     }
 
     public List<String> getSupportedCommands() {

--- a/src/main/java/com/cisco/trex/stateless/model/stats/XstatsNames.java
+++ b/src/main/java/com/cisco/trex/stateless/model/stats/XstatsNames.java
@@ -1,0 +1,22 @@
+package com.ericsson.commonlibrary.trex;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * statistics for trex port
+ */
+public class XstatsNames {
+
+    /**
+     * Json property
+     */
+    @JsonProperty("xstats_names")
+    public String[] names;
+
+    /**
+     * @return names
+     */
+    public String[] getAllNames() {
+        return names;
+    }
+}

--- a/src/main/java/com/cisco/trex/stateless/model/stats/XstatsNames.java
+++ b/src/main/java/com/cisco/trex/stateless/model/stats/XstatsNames.java
@@ -1,4 +1,4 @@
-package com.ericsson.commonlibrary.trex;
+package com.cisco.trex.stateless.model.stats;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 


### PR DESCRIPTION
merges and e2e tests for

https://github.com/cisco-system-traffic-generator/trex-java-sdk/pull/36
https://github.com/cisco-system-traffic-generator/trex-java-sdk/pull/35
https://github.com/cisco-system-traffic-generator/trex-java-sdk/pull/34

Added Dockerfile, that could be used for e2e testing of trex-java-sdk and trex-stateless-gui