### PR TITLE
Histogram class need to be public

### DIFF
--- a/src/main/java/com/cisco/trex/stateful/model/stats/LatencyPortHist.java
+++ b/src/main/java/com/cisco/trex/stateful/model/stats/LatencyPortHist.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class LatencyPortHist {
 
-    private static class Histogram{
+    public static class Histogram{
         @SerializedName("key")
         public Integer key;
 


### PR DESCRIPTION
Maybe we need to expose Histogram class to client, because client use getList method which returns `List<Histogram>` and not the method which returns the field value of Histogram, I forget this and make it private.