### PR TITLE
ASTFCmdRecvMsg.java used 'tx_msg' instead of 'rx_msg' when init Name proterty

### DIFF
--- a/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFCmdRecvMsg.java
+++ b/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFCmdRecvMsg.java
@@ -4,7 +4,7 @@ package com.cisco.trex.stateful.api.lowlevel;
  * Java implementation for TRex python sdk ASTFCmdRecvMsg class
  */
 public class ASTFCmdRecvMsg extends ASTFCmd {
-    private static final String NAME = "tx_msg";
+    private static final String NAME = "rx_msg";
 
     /**
      * construct


### PR DESCRIPTION
ASTFCmdRecvMsg.java used 'tx_msg' instead of 'rx_msg' when init Name proterty