### PR TITLE
Support new json response format

### DIFF
--- a/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
+++ b/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
@@ -36,7 +36,7 @@ public class TRexClientTest {
 
     @BeforeClass
     public static void setUp() throws TRexConnectionException, TRexTimeoutException {
-        client = new TRexClient("10.76.176.8", "4501", CLIENT_USER);
+        client = new TRexClient("trex-host", "4501", CLIENT_USER);
         client.connect();
     }
 

--- a/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
+++ b/src/e2e-test/java/com/cisco/trex/stateless/TRexClientTest.java
@@ -36,7 +36,7 @@ public class TRexClientTest {
 
     @BeforeClass
     public static void setUp() throws TRexConnectionException, TRexTimeoutException {
-        client = new TRexClient("trex-host", "4501", CLIENT_USER);
+        client = new TRexClient("10.76.176.8", "4501", CLIENT_USER);
         client.connect();
     }
 

--- a/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java
+++ b/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java
@@ -231,12 +231,11 @@ public class TRexAstfClient extends ClientBase {
         payload.put("force", force);
         payload.put("port_id", portIndex);
         String json = callMethod("acquire", payload);
-        JsonElement response = new JsonParser().parse(json);
         Set<Entry<String, JsonElement>> entrySet;
         try {
-            this.masterHandler = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonObject()
+            this.masterHandler = getResultFromResponse(json).getAsJsonObject()
                     .get("handler").getAsString();
-            entrySet = response.getAsJsonArray().get(0).getAsJsonObject().get("result")
+            entrySet = getResultFromResponse(json)
                     .getAsJsonObject()
                     .get("ports").getAsJsonObject().entrySet();
         } catch (NullPointerException e) {
@@ -316,8 +315,7 @@ public class TRexAstfClient extends ClientBase {
     public List<String> getProfileIds() {
         Map<String, Object> payload = createPayload();
         String json = callMethod("get_profile_list", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonArray ids = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonArray();
+        JsonArray ids = getResultFromResponse(json).getAsJsonArray();
         return StreamSupport.stream(ids.spliterator(), false)
                 .map(JsonElement::getAsString)
                 .collect(Collectors.toList());
@@ -359,8 +357,7 @@ public class TRexAstfClient extends ClientBase {
     public LatencyStats getLatencyStats() {
         Map<String, Object> payload = this.createPayload();
         String json = this.callMethod("get_latency_stats", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonElement latencyStatsJsonElement = response.getAsJsonArray().get(0).getAsJsonObject().get("result");
+        JsonElement latencyStatsJsonElement = getResultFromResponse(json);
         //only can parse a part of data, LatencyPortData need to be parsed manually.
         LatencyStats latencyStats = GSON.fromJson(latencyStatsJsonElement, LatencyStats.class);
         JsonElement latencyDataJsonElement = latencyStatsJsonElement.getAsJsonObject().get("data");
@@ -387,9 +384,8 @@ public class TRexAstfClient extends ClientBase {
     public String getVersion() {
         Map<String, Object> payload = this.createPayload();
         String json = callMethod("get_version", payload);
-        JsonElement response = new JsonParser().parse(json);
         try {
-            return response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonObject()
+            return getResultFromResponse(json).getAsJsonObject()
                     .get("version").getAsString();
         } catch (NullPointerException e) {
             throw new IllegalStateException("could not parse version", e);
@@ -415,8 +411,7 @@ public class TRexAstfClient extends ClientBase {
         Map<String, Object> payload = createPayload(profileId);
         payload.put("initialized", false);
         String json = callMethod("get_tg_names", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonArray names = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonObject()
+        JsonArray names = getResultFromResponse(json).getAsJsonObject()
                 .get("tg_names").getAsJsonArray();
         return StreamSupport.stream(names.spliterator(), false)
                 .map(JsonElement::getAsString)
@@ -452,8 +447,7 @@ public class TRexAstfClient extends ClientBase {
         payload.put("tg_ids", new ArrayList<>(name2Id.values()));
 
         String json = callMethod("get_tg_id_stats", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonObject result = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonObject();
+        JsonObject result = getResultFromResponse(json).getAsJsonObject();
         MetaData metaData = getAstfStatsMetaData();
         name2Id.forEach((tgName, tgId) ->{
             try {

--- a/src/main/java/com/cisco/trex/stateless/TRexClient.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexClient.java
@@ -108,8 +108,7 @@ public class TRexClient extends ClientBase {
         payload.put("user", userName);
         payload.put("force", force);
         String json = callMethod("acquire", payload);
-        JsonElement response = new JsonParser().parse(json);
-        String handler = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsString();
+        String handler = getResultFromResponse(json).getAsString();
         portHandlers.put(portIndex, handler);
         return getPortStatus(portIndex).get();
     }
@@ -163,8 +162,7 @@ public class TRexClient extends ClientBase {
 
         String json = callMethod("get_stream", payload);
         JsonElement response = new JsonParser().parse(json);
-        JsonObject stream = response.getAsJsonArray().get(0)
-                .getAsJsonObject().get("result")
+        JsonObject stream = getResultFromResponse(json)
                 .getAsJsonObject().get("stream")
                 .getAsJsonObject();
         return GSON.fromJson(stream, Stream.class);
@@ -199,8 +197,7 @@ public class TRexClient extends ClientBase {
         Map<String, Object> payload = createPayload(portIndex, profileId);
         String json = callMethod("get_all_streams", payload);
         JsonElement response = new JsonParser().parse(json);
-        JsonObject streams = response.getAsJsonArray().get(0)
-                .getAsJsonObject().get("result")
+        JsonObject streams = getResultFromResponse(json)
                 .getAsJsonObject().get("streams")
                 .getAsJsonObject();
         ArrayList<Stream> streamList = new ArrayList<>();
@@ -219,8 +216,7 @@ public class TRexClient extends ClientBase {
     public List<Integer> getStreamIds(int portIndex, String profileId) {
         Map<String, Object> payload = createPayload(portIndex, profileId);
         String json = callMethod("get_stream_list", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonArray ids = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonArray();
+        JsonArray ids = getResultFromResponse(json).getAsJsonArray();
         return StreamSupport.stream(ids.spliterator(), false)
                 .map(JsonElement::getAsInt)
                 .collect(Collectors.toList());
@@ -250,8 +246,7 @@ public class TRexClient extends ClientBase {
     public List<String> getProfileIds(int portIndex) {
         Map<String, Object> payload = createPayload(portIndex);
         String json = callMethod("get_profile_list", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonArray ids = response.getAsJsonArray().get(0).getAsJsonObject().get("result").getAsJsonArray();
+        JsonArray ids = getResultFromResponse(json).getAsJsonArray();
         return StreamSupport.stream(ids.spliterator(), false)
                 .map(JsonElement::getAsString)
                 .collect(Collectors.toList());
@@ -542,9 +537,7 @@ public class TRexClient extends ClientBase {
 
         Map<String, Object> payload = createPayload(portIndex);
         String json = callMethod("get_rx_queue_pkts", payload);
-        JsonElement response = new JsonParser().parse(json);
-        JsonArray pkts = response.getAsJsonArray().get(0)
-                .getAsJsonObject().get("result")
+        JsonArray pkts = getResultFromResponse(json)
                 .getAsJsonObject()
                 .getAsJsonArray("pkts");
         return StreamSupport.stream(pkts.spliterator(), false)

--- a/src/main/java/com/cisco/trex/stateless/TRexTransport.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexTransport.java
@@ -62,7 +62,7 @@ public class TRexTransport {
     }
 
     public RPCResponse[] sendCommands(List<TRexCommand> commands) throws IOException {
-        if (commands.size() ==1) {
+        if (commands.size() == 1) {
             return new RPCResponse[] {sendCommand(commands.get(0))};
         }
 

--- a/src/main/java/com/cisco/trex/stateless/TRexTransport.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexTransport.java
@@ -52,8 +52,13 @@ public class TRexTransport {
     public RPCResponse sendCommand(TRexCommand command) throws IOException {
         String json = new ObjectMapper().writeValueAsString(command.getParameters());
         String response = sendJson(json);
-        RPCResponse[] rpcResult = new ObjectMapper().readValue(response, RPCResponse[].class);
-        return rpcResult[0];
+        ObjectMapper objectMapper = new ObjectMapper();
+        if (objectMapper.readTree(response).isArray()) {
+            // for versions of TRex before v2.61, single entry response also wrapped with json array
+            RPCResponse[] rpcResult = objectMapper.readValue(response, RPCResponse[].class);
+            return rpcResult[0];
+        }
+        return objectMapper.readValue(response, RPCResponse.class);
     }
 
     public RPCResponse[] sendCommands(List<TRexCommand> commands) throws IOException {

--- a/src/main/java/com/cisco/trex/stateless/TRexTransport.java
+++ b/src/main/java/com/cisco/trex/stateless/TRexTransport.java
@@ -62,6 +62,10 @@ public class TRexTransport {
     }
 
     public RPCResponse[] sendCommands(List<TRexCommand> commands) throws IOException {
+        if (commands.size() ==1) {
+            return new RPCResponse[] {sendCommand(commands.get(0))};
+        }
+
         List<Map<String, Object>> commandList = commands.stream().map(TRexCommand::getParameters).collect(Collectors.toList());
         
         if (commandList.isEmpty()) {


### PR DESCRIPTION
Since next trex-core, the json response format will be changed as below rules:
   - if entry size is bigger than 1 then it'll be arrary [],
   - otherwise it'll be single entry "{}"

in trex-java-sdk, both formats needs to be supported for current trex-core version and later new versions.

For example, in current trex-core version

Response code of api_sync_v2 was:
[
{
"id": "o3jbrrru",
"jsonrpc": "2.0",
"result":

{ "api_h": "FMuiZHtB" }
}
]


Since next trex-core version

Response code of api_sync_v2 will be changed to 
{
"id": "ywiri9kt",
"jsonrpc": "2.0",
"result":

{ "api_h": "r476neXW" }
}