### PR TITLE
TRex sends IPv6 neighbor solicitation packets with incorrect source IP

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
+++ b/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
@@ -11,7 +11,6 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.pcap4j.packet.*;
 import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
@@ -585,8 +584,8 @@ public class IPv6NeighborDiscoveryService {
       strOctets.add(
           String.format(
               "%s%s",
-                  StringUtils.leftPad(Integer.toHexString(macOctets.get(i)), 2, "0"),
-                  StringUtils.leftPad(Integer.toHexString(macOctets.get(i + 1)), 2, "0")));
+              StringUtils.leftPad(Integer.toHexString(macOctets.get(i)), 2, "0"),
+              StringUtils.leftPad(Integer.toHexString(macOctets.get(i + 1)), 2, "0")));
     }
     return String.format("%s::%s", prefix, String.join(":", strOctets));
   }

--- a/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
+++ b/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
@@ -567,7 +567,7 @@ public class IPv6NeighborDiscoveryService {
     return Arrays.stream(addressArray).collect(Collectors.joining(":"));
   }
 
-  private static String generateIPv6AddrFromMAC(String mac) {
+  static String generateIPv6AddrFromMAC(String mac) {
     String prefix = "fe80";
     List<Integer> macOctets =
         Arrays.stream(mac.split(":"))

--- a/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
+++ b/src/main/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryService.java
@@ -11,6 +11,8 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
 import org.pcap4j.packet.*;
 import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
 import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket.IcmpV6NeighborAdvertisementHeader;
@@ -583,7 +585,8 @@ public class IPv6NeighborDiscoveryService {
       strOctets.add(
           String.format(
               "%s%s",
-              Integer.toHexString(macOctets.get(i)), Integer.toHexString(macOctets.get(i + 1))));
+                  StringUtils.leftPad(Integer.toHexString(macOctets.get(i)), 2, "0"),
+                  StringUtils.leftPad(Integer.toHexString(macOctets.get(i + 1)), 2, "0")));
     }
     return String.format("%s::%s", prefix, String.join(":", strOctets));
   }

--- a/src/test/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryServiceTest.java
+++ b/src/test/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryServiceTest.java
@@ -1,6 +1,7 @@
 package com.cisco.trex.stateless;
 
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class IPv6NeighborDiscoveryServiceTest {
@@ -10,5 +11,4 @@ public class IPv6NeighborDiscoveryServiceTest {
     String ipV6Address = IPv6NeighborDiscoveryService.generateIPv6AddrFromMAC("10:62:E5:09:A0:64");
     assertEquals("fe80::1262:e5ff:fe09:a064", ipV6Address);
   }
-
 }

--- a/src/test/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryServiceTest.java
+++ b/src/test/java/com/cisco/trex/stateless/IPv6NeighborDiscoveryServiceTest.java
@@ -1,0 +1,14 @@
+package com.cisco.trex.stateless;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class IPv6NeighborDiscoveryServiceTest {
+
+  @Test
+  public void generateIPv6AddrFromMACTest() {
+    String ipV6Address = IPv6NeighborDiscoveryService.generateIPv6AddrFromMAC("10:62:E5:09:A0:64");
+    assertEquals("fe80::1262:e5ff:fe09:a064", ipV6Address);
+  }
+
+}


### PR DESCRIPTION
If a integer translates to hex, for example: 254 -> 0xff, 9 -> 0x9,  and contact them, the result is "ff9", there is a mistake, the correct result is "ff09" in ip/mac style. we can use StringUtils.leftPad to left pad with "0" for one-digit, such as 9, then it become right.