### PR TITLE
align with ASTFProgram in trex_astf_profile.py for recv and recv_msg API

### DIFF
--- a/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
+++ b/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
@@ -345,7 +345,7 @@ public class ASTFProgram {
    * @param clear
    */
   public void recv(long bytes, boolean clear) {
-    if(clear){
+    if (clear) {
       this.totalRcvBytes = 0;
     }
     this.totalRcvBytes += bytes;
@@ -391,7 +391,7 @@ public class ASTFProgram {
    * @param clear when reach the watermark clear the flow counter
    */
   public void recvMsg(long pkts, boolean clear) {
-    if(clear){
+    if (clear) {
       this.totalRcvBytes = 0;
     }
     this.totalRcvBytes += pkts;

--- a/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
+++ b/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
@@ -345,6 +345,9 @@ public class ASTFProgram {
    * @param clear
    */
   public void recv(long bytes, boolean clear) {
+    if(clear == true){
+      this.totalRcvBytes = 0;
+    }
     this.totalRcvBytes += bytes;
     fields.get(COMMANDS).add(new ASTFCmdRecv(totalRcvBytes, clear));
   }
@@ -388,6 +391,9 @@ public class ASTFProgram {
    * @param clear when reach the watermark clear the flow counter
    */
   public void recvMsg(long pkts, boolean clear) {
+    if(clear == true){
+      this.totalRcvBytes = 0;
+    }
     this.totalRcvBytes += pkts;
     fields.get(COMMANDS).add(new ASTFCmdRecvMsg(this.totalRcvBytes, clear));
   }

--- a/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
+++ b/src/main/java/com/cisco/trex/stateful/api/lowlevel/ASTFProgram.java
@@ -345,7 +345,7 @@ public class ASTFProgram {
    * @param clear
    */
   public void recv(long bytes, boolean clear) {
-    if(clear == true){
+    if(clear){
       this.totalRcvBytes = 0;
     }
     this.totalRcvBytes += bytes;
@@ -391,7 +391,7 @@ public class ASTFProgram {
    * @param clear when reach the watermark clear the flow counter
    */
   public void recvMsg(long pkts, boolean clear) {
-    if(clear == true){
+    if(clear){
       this.totalRcvBytes = 0;
     }
     this.totalRcvBytes += pkts;


### PR DESCRIPTION
Just align with https://github.com/cisco-system-traffic-generator/trex-core/blob/master/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py. which will reset the min_bytes when set clear parameter to true.