### PR TITLE
cache counter meta data in both stl and astf mode

### DIFF
--- a/src/main/java/com/cisco/trex/ClientBase.java
+++ b/src/main/java/com/cisco/trex/ClientBase.java
@@ -62,6 +62,7 @@ public abstract class ClientBase {
   protected TRexTransport transport;
   protected String apiH;
   protected String masterHandler;
+  private XstatsNames xstatsNames;
 
   private static Gson buildGson() {
     GsonBuilder gsonBuilder = new GsonBuilder();
@@ -360,9 +361,13 @@ public abstract class ClientBase {
   }
 
   private XstatsNames getPortStatNames(int portIndex) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put(PORT_ID, portIndex);
-    return callMethod("get_port_xstats_names", parameters, XstatsNames.class).get();
+    if (xstatsNames == null) {
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put(PORT_ID, portIndex);
+      xstatsNames = callMethod("get_port_xstats_names", parameters, XstatsNames.class).get();
+    }
+
+    return xstatsNames;
   }
 
   /**

--- a/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java
+++ b/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 public class TRexAstfClient extends ClientBase {
 
   private static final String ASTF = "ASTF";
+  private MetaData counterMetaData;
 
   /**
    * @param host
@@ -359,8 +360,12 @@ public class TRexAstfClient extends ClientBase {
   }
 
   private MetaData getAstfStatsMetaData() {
-    Map<String, Object> payload = createPayload();
-    return callMethod("get_counter_desc", payload, MetaData.class).get();
+    if (counterMetaData == null) {
+      Map<String, Object> payload = createPayload();
+      counterMetaData = callMethod("get_counter_desc", payload, MetaData.class).get();
+    }
+
+    return counterMetaData;
   }
 
   /**


### PR DESCRIPTION
Each call of getExtendedPortStatistics in stl and getAstfStatistics in astf will printout lot of logs of the counter description(meta data), to save it and avoid unnecessary calling, cache the meta data when the first calling.