### PR TITLE
add aliases for global stats to adapt the counter name change in trex-core

### DIFF
--- a/src/main/java/com/cisco/trex/stateless/model/stats/GlobalStatistics.java
+++ b/src/main/java/com/cisco/trex/stateless/model/stats/GlobalStatistics.java
@@ -1,6 +1,8 @@
 package com.cisco.trex.stateless.model.stats;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class GlobalStatistics {
 
@@ -49,16 +51,19 @@ public class GlobalStatistics {
   @JsonProperty("m_total_clients")
   private long mTotalClients = 0;
 
-  @JsonProperty("m_total_nat_active ")
+  @JsonProperty("m_total_nat_active")
+  @JsonAlias("m_total_nat_active ")
   private long mTotalNatActive = 0;
 
   @JsonProperty("m_total_nat_learn_error")
   private long mTotalNatLearnError = 0;
 
-  @JsonProperty("m_total_nat_no_fid ")
+  @JsonProperty("m_total_nat_no_fid")
+  @JsonAlias("m_total_nat_no_fid ")
   private long mTotalNatNoFid = 0;
 
-  @JsonProperty("m_total_nat_open   ")
+  @JsonProperty("m_total_nat_open")
+  @JsonAlias("m_total_nat_open   ")
   private long mTotalNatOpen = 0;
 
   @JsonProperty("m_total_nat_syn_wait")
@@ -184,7 +189,7 @@ public class GlobalStatistics {
     return mTotalClients;
   }
 
-  @JsonProperty("m_total_nat_active ")
+  @JsonProperty("m_total_nat_active")
   public long getMTotalNatActive() {
     return mTotalNatActive;
   }
@@ -194,12 +199,12 @@ public class GlobalStatistics {
     return mTotalNatLearnError;
   }
 
-  @JsonProperty("m_total_nat_no_fid ")
+  @JsonProperty("m_total_nat_no_fid")
   public long getMTotalNatNoFid() {
     return mTotalNatNoFid;
   }
 
-  @JsonProperty("m_total_nat_open ")
+  @JsonProperty("m_total_nat_open")
   public long getMTotalNatOpen() {
     return mTotalNatOpen;
   }

--- a/src/main/java/com/cisco/trex/stateless/model/stats/GlobalStatistics.java
+++ b/src/main/java/com/cisco/trex/stateless/model/stats/GlobalStatistics.java
@@ -2,7 +2,6 @@ package com.cisco.trex.stateless.model.stats;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class GlobalStatistics {
 


### PR DESCRIPTION
To adapt the global stats counter name change in https://github.com/cisco-system-traffic-generator/trex-core/pull/687, add aliases for the impacted json fields