### PR TITLE
CRITICAL vulnerability: bump jackson from 2.9.8 to 2.9.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile group: 'org.zeromq', name: 'jeromq', version:'0.5.1'
     compile group: 'com.google.code.gson', name: 'gson', version:'2.8.5'
     compile group: 'com.google.guava', name: 'guava', version: '27.1-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.8'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.10'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
 


### PR DESCRIPTION
# Vulnerability Information

Bumps [jackson-databind](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.8) from 2.9.8 to 2.9.10.

Listed dependency **com.fasterxml.jackson.core:jackson-databind** contains vulnerable methods which are called from this project. This vulnerability appears to affect *jackson-databind* package versions lower than 2.9.9.2 (excluding). The vulnerability has been fixed in version 2.9.9.2, as can be seen from the linked CVE or package [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9) -
the micro-patch of 2.9.9.2 refers to the fix of this vulnerability.

The jackson-core package has also been bumped to 2.9.10, due to compatibility reasons with the bumped jackson-databind package.

| <center>Property</center> | <center>Value</center> |
|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
| <center> Linked CVE </center> | CVE-2019-14379                                                                                |
| <center> Number of affected methods </center> | 10+                                                                                                                |
| <center>Severity</center> | **CRITICAL**                                                                                                                                     |
| <center>Current version</center> | 2.9.8                                                                                                                                        |
| <center>Updated version</center> | 2.9.10                                                                                                                                    |
| <center>Backwards Compatibility</center> | True                                                                                                                         | 


# Vulnerable method calls

| Methods in this repository                                                    | Used package methods                                           | Origin vulnerable method                                          |
|----------|---------------------------------------|------------------------------------------------------------------------|
| [com.cisco.trex/ClientBase.callMethod(String methodName, Map<String, Object> parameters, Class<T> responseType)][1] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.introspect/<br>AnnotatedCreatorCollector.constructNonDefaultConstructor(ClassUtil.Ctor ctor, ClassUtil.Ctor mixin) |
| [com.cisco.trex/ClientBase.callMethod(String methodName, Map<String, Object> parameters, Class<T> responseType)][1] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.cisco.trex/ClientBase.callMethod(String methodName, Map<String, Object> parameters, Class<T> responseType)][1] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.deser/<br>BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |
| [com.cisco.trex.stateful/TRexAstfClient.getTemplateGroupStatistics(String profileId, List<String> tgNames)][2] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.introspect/<br>AnnotatedCreatorCollector.constructNonDefaultConstructor(ClassUtil.Ctor ctor, ClassUtil.Ctor mixin) |
| [com.cisco.trex.stateful/TRexAstfClient.getTemplateGroupStatistics(String profileId, List<String> tgNames)][2] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
| [com.cisco.trex.stateful/TRexAstfClient.getTemplateGroupStatistics(String profileId, List<String> tgNames)][2] | com.fasterxml.jackson.databind/<br>ObjectMapper.readValue(String content, Class<T> valueType) | com.fasterxml.jackson.databind.deser/<br>BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |

### Whole set of methods

To see the whole set of methods that are affected, please take a look at the table in the markdown file [here](https://github.com/MethodLevelAnalyzer/vulnerability-findings/blob/e9c5fde265a00b4c064a502c4b9bc5b9506df18b/results/cisco-system-traffic-generator__trex-java-sdk____CVE-2019-14379.md).

[1]: https://github.com/cisco-system-traffic-generator/trex-java-sdk/blob/6684f1e8ab8e788818b8cacb82488fea889f113a/src/main/java/com/cisco/trex/ClientBase.java#L191
[2]:  https://github.com/cisco-system-traffic-generator/trex-java-sdk/blob/6684f1e8ab8e788818b8cacb82488fea889f113a/src/main/java/com/cisco/trex/stateful/TRexAstfClient.java#L487

### What do the columns represent?
The 1st column in the table indicates the method in this repository that was found to be affected by vulnerable methods from the *jackson-databind* package.

The 2nd column indicates the *jackson-databind* method that was directly called from this repository.

The 3rd column indicates the origin vulnerable method in the *jackson-databind* package. According to our dataset, this is one of the methods that produces the **CVE-2019-14379** vulnerability. This method was found to be internally chain-called in the *jackson-databind* package by the method listed in column 2.


### How were the results generated?
This vulnerability was analyzed specifically for usage in this project using the [FASTEN Project](https://www.fasten-project.eu/view/Main/). Statical method-level analysis was used to check for usage of vulnerable methods in the project.

Method calls between your project and *jackson-databind* have been mapped using a directed graph. From this graph, it could be then be seen whether any vulnerable *jackson-databind* methods are being called from within your project.

# Research Scope

We are a [team](https://github.com/orgs/TU-Delft-Research-Group-2021/people) of 3 BSc Computer Science students at the TU Delft. Our goal is to conduct research on how developers react to method-level vulnerability information that affects their projects. We would highly appreciate if you could help us with our research and please tick statements which apply to you below.

### First impression checklist
- [ ] I have read this pull request description.
- [ ] I was aware of this dependency vulnerability affecting my project before being informed by this Pull Request.
- [ ] I was convinced by the provided method information that this vulnerability indeed affects my project.
- [ ] After seeing the provided method-level information, I plan on fixing the vulnerability.

### After fixing vulnerability checklist
- [ ] I found that the provided method information has made my process of dealing with the vulnerable dependency easier.
- [ ] I have given priority to the task of fixing the vulnerability over other project tasks that are yet to be completed.
- [ ] I would like to receive this kind of method information in future vulnerable dependency Pull Request descriptions.

<img align="right" src="https://user-images.githubusercontent.com/52587121/119507191-e6226c80-bd6e-11eb-8c2a-306309777e0f.png" hspace="20" width="150"/>