### PR TITLE
Uplift log4j version to 2.24.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile group: 'org.pcap4j', name: 'pcap4j-packetfactory-static', version:'1.7.7' //1.8.0+ requires java 9
     compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.9'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.24.3'
     compile group: 'org.zeromq', name: 'jeromq', version:'0.5.1'
     compile group: 'com.google.code.gson', name: 'gson', version:'2.8.5'
     compile group: 'com.google.guava', name: 'guava', version: '27.1-jre'


### PR DESCRIPTION
Please check if it is possible to uplift log4j version to 2.24.3.